### PR TITLE
Added timestamps in ExampleSettingsSeeder

### DIFF
--- a/src/Davzie/LaravelBootstrap/Seeds/ExampleSettingsSeeder.php
+++ b/src/Davzie/LaravelBootstrap/Seeds/ExampleSettingsSeeder.php
@@ -13,7 +13,9 @@ class ExampleSettingsSeeder extends Seeder {
             [
                 'key'           => 'application_name',
                 'label'         => 'Application Name',
-                'value'         => Config::get('laravel-bootstrap::app.name')
+                'value'         => Config::get('laravel-bootstrap::app.name'),
+                'created_at'    => date('Y-m-d H:i:s'),
+                'updated_at'    => date('Y-m-d H:i:s')
             ]
         ];
         DB::table('settings')->insert($types);


### PR DESCRIPTION
``````
action@freelance-80648:~/workspace/your-project-name$ php artisan db:seed --class="Davzie\LaravelBootstrap\Seeds\DatabaseSeeder"                                                                                                    
User Table Seeded                                                                                                                                                                                                                   
Seeded: Davzie\LaravelBootstrap\Seeds\ExampleUserSeeder                                                                                                                                                                             



  [Illuminate\Database\QueryException]                                                                                                                                                                                              
  SQLSTATE[23000]: Integrity constraint violation: 19 settings.created_at may not be NULL (SQL: insert into "settings" ("key", "label", "value") values (application_name, Application Name, Savico CMS))                           



db:seed [--class[="..."]] [--database[="..."]]                                                                                                                                                                                      
                                                                                                                                                                                                                                    ```
``````
